### PR TITLE
Rework: add chrony dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 wtd_time_timezone: "Europe/London"
+
+wtd_time_daemon: "chrony"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,5 @@
-dependencies: []
+dependencies:
+ - { role: while-true-do.chrony, when: wtd_time_daemon == "chrony" }
 
 galaxy_info:
   author: while-true-do.org


### PR DESCRIPTION
- chrony now gets installed per default
- could be changed to ntp or timesyncd later
  just change wtd_time_daemon to another value

## Reference
 - Resolves: #1 